### PR TITLE
Feature s3 client store file fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt --use-mirrors"
-  - pip install coveralls --use-mirrors
+  - "pip install -r requirements.txt"
+  - pip install coveralls
 # command to run tests
 script:
 - "nosetests --with-coverage --cover-erase --cover-branches --cover-package=the_ark"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto==2.29.1
-coverage==3.7.1
+coverage==4.4.2
 flake8==2.3.0
 jsonschema
 mandrill==1.0.57

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 
 setup(
     name="theark",
-    version="0.0.6",
+    version="0.0.8",
     author="meltmedia QA Team",
     author_email="qa-d@meltmedia.com",
     description="meltQA Tools Common Library.",
@@ -23,7 +23,7 @@ setup(
         install_requires=[
         "boto >= 2.29.1",
         "requests >= 2.3.0",
-        "selenium >= 2.45.0"
+        "selenium >= 2.53.0"
     ],
     classifiers=[
         "Development Status :: 1 - Planning",

--- a/tests/test_selenium_helpers.py
+++ b/tests/test_selenium_helpers.py
@@ -330,7 +330,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_valid(self):
         valid_css_selector = ".valid"
-        self.assertEqual(self.sh.get_element(valid_css_selector).location, {'y': 21, 'x': 48})
+        self.assertEqual(self.sh.get_element(valid_css_selector).location, {'y': 21.4375, 'x': 48})
 
     def test_get_invalid(self):
         self.assertRaises(selenium_helpers.ElementError, self.sh.get_element, ".invalid")

--- a/the_ark/s3_client.py
+++ b/the_ark/s3_client.py
@@ -9,6 +9,8 @@ import urlparse
 from boto.s3.key import Key
 from StringIO import StringIO
 
+from hippo import util
+log = util.create_logger("S3 Client")
 
 class S3Client(object):
     """A client that helps user to send and get files from S3"""
@@ -66,30 +68,42 @@ class S3Client(object):
             s3_file.set_metadata('Content-Type', mime_type)
 
             # - Check if file is a buffer or disk file and if file that is getting uploaded is greater than
-            # chunk_at_size then upload cool multi style
-            if type(file_to_store) == str and os.path.getsize(file_to_store) > chunk_at_size:
-                file_count = 0
-                # - Split the file and get it chunky
-                split_file_dir = self._split_file(file_to_store)
+            #   chunk_at_size then upload cool multi style
+            split_file_dir = None
+            mutli_part_upload_successful = False
+            try:
+                if type(file_to_store) == str and os.path.getsize(file_to_store) > chunk_at_size:
+                    file_count = 0
+                    # - Split the file and get it chunky
+                    split_file_dir = self._split_file(file_to_store)
 
-                # - Initiate the file to be uploaded in parts
-                multipart_file = self.bucket.initiate_multipart_upload(key_name=s3_file.key, metadata=s3_file.metadata)
+                    # - Initiate the file to be uploaded in parts
+                    multipart_file = self.bucket.initiate_multipart_upload(key_name=s3_file.key, metadata=s3_file.metadata)
 
-                # - Upload the file parts
-                for files in os.listdir(split_file_dir):
-                    file_count += 1
-                    file_part = open(os.path.join(split_file_dir, files), 'rb')
-                    multipart_file.upload_part_from_file(file_part, file_count)
+                    # - Upload the file parts
+                    for files in os.listdir(split_file_dir):
+                        file_count += 1
+                        file_part = open(os.path.join(split_file_dir, files), 'rb')
+                        multipart_file.upload_part_from_file(file_part, file_count)
 
-                # - Complete the upload
-                multipart_file.complete_upload()
-
+                    # - Complete the upload
+                    multipart_file.complete_upload()
+                    mutli_part_upload_successful = True
+            except S3ResponseError as s3_error:
+                log.warning("A S3 Response error was caught while attempting to chunk and upload the PDF | {}\n"
+                            "Will now attempt to send the file as a whole...".format(s3_error))
+            except Exception as s3_error:
+                log.warning("Unexpected Error encountered an issue while chunking and uploading the PDF | {}\n"
+                            "Will now attempt to send the file as a whole...".format(s3_error))
+            finally:
                 # - Remove the folder from splitting the file
-                shutil.rmtree(split_file_dir)
+                if split_file_dir:
+                    shutil.rmtree(split_file_dir)
 
             # - Upload the file as a whole
-            else:
-                # - Determine whether the file_to_store is an object or file path/string
+            # else:
+            # - Determine whether the file_to_store is an object or file path/string
+            if not mutli_part_upload_successful:
                 file_type = type(file_to_store)
                 if file_type in [str, unicode]:
                     s3_file.set_contents_from_filename(file_to_store)
@@ -229,12 +243,12 @@ class S3Client(object):
                 fileobject = open(filename, 'wb')
                 fileobject.write(chunk)
                 fileobject.close()  # or simply open(  ).write(  )
+                log.info("File Part #{} size: {}".format(part_number, os.path.getsize(filename)))
             input_file.close()
             assert part_number <= 9999  # join sort fails if 5 digits
             return temp_dir
         except Exception as e:
-            print "Could not split the file.\nError: {}\n".format(e)
-            raise e
+            raise S3ClientException("Could not split the file.\nError: {}\n".format(e))
 
 
 class S3ClientException(Exception):

--- a/the_ark/s3_client.py
+++ b/the_ark/s3_client.py
@@ -76,7 +76,7 @@ class S3Client(object):
             # - Check if file is a buffer or disk file and if file that is getting uploaded is greater than
             #   chunk_at_size then upload cool multi style
             mutli_part_upload_successful = False
-            if type(file_to_store) == str and os.path.getsize(file_to_store) > chunk_at_size:
+            if isinstance(file_to_store, str) and os.path.getsize(file_to_store) > chunk_at_size:
                 split_file_dir = None
                 multipart_file = self.bucket.initiate_multipart_upload(key_name=s3_file.key, metadata=s3_file.metadata)
 
@@ -238,6 +238,8 @@ class S3Client(object):
         """
         if os.path.getsize(from_file) > (MAX_FILE_SPLITS * file_chunk_size):
             raise S3ClientException("Could not split the file.\nError: Input file is too large!\n")
+        elif os.path.getsize(from_file) < DEFAULT_FILE_SPLIT_SIZE:
+            raise S3ClientException("Could not split the file.\nError: Input file is too small!\n")
 
         try:
             temp_dir = tempfile.mkdtemp()

--- a/the_ark/s3_client.py
+++ b/the_ark/s3_client.py
@@ -5,12 +5,13 @@ import shutil
 import tempfile
 import urllib
 import urlparse
+import logging
 
 from boto.s3.key import Key
 from StringIO import StringIO
 
-from hippo import util
-log = util.create_logger("S3 Client")
+logger = logging.getLogger(__name__)
+
 
 class S3Client(object):
     """A client that helps user to send and get files from S3"""
@@ -89,12 +90,12 @@ class S3Client(object):
                     # - Complete the upload
                     multipart_file.complete_upload()
                     mutli_part_upload_successful = True
-            except S3ResponseError as s3_error:
-                log.warning("A S3 Response error was caught while attempting to chunk and upload the PDF | {}\n"
-                            "Will now attempt to send the file as a whole...".format(s3_error))
+            except boto.s3.connection.S3ResponseError as s3_error:
+                logger.warning("A S3 Response error was caught while attempting to chunk and upload the PDF | {}\n"
+                               "Will now attempt to send the file as a whole...".format(s3_error))
             except Exception as s3_error:
-                log.warning("Unexpected Error encountered an issue while chunking and uploading the PDF | {}\n"
-                            "Will now attempt to send the file as a whole...".format(s3_error))
+                logger.warning("Unexpected Error encountered an issue while chunking and uploading the PDF | {}\n"
+                               "Will now attempt to send the file as a whole...".format(s3_error))
             finally:
                 # - Remove the folder from splitting the file
                 if split_file_dir:
@@ -243,7 +244,6 @@ class S3Client(object):
                 fileobject = open(filename, 'wb')
                 fileobject.write(chunk)
                 fileobject.close()  # or simply open(  ).write(  )
-                log.info("File Part #{} size: {}".format(part_number, os.path.getsize(filename)))
             input_file.close()
             assert part_number <= 9999  # join sort fails if 5 digits
             return temp_dir


### PR DESCRIPTION
* Refactors store file and split file logic in the s3_client
  - Adds logging
  - Ensures temp directory is removed and the multipart upload is completed or aborted
  - Full file upload is now attempted if multipart upload fails
  - Updates default file split size to 6 MB to prevent multipart upload failure on unix machines

* Updates travis config, removes deprecated flag
* Updates coverage version to the latest