### PR TITLE
Feature qap 1260

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ nose==1.3.1
 numpy==1.9.2
 pillow==2.9.0
 requests==2.3.0
-selenium==2.53.5
+selenium==3.11.0

--- a/tests/test_selenium_helpers.py
+++ b/tests/test_selenium_helpers.py
@@ -13,7 +13,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.sh = selenium_helpers.SeleniumHelpers()
-        cls.driver = cls.sh.create_driver(browserName="phantomjs")
+        cls.driver = cls.sh.create_driver(browserName="chrome", headless=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -21,7 +21,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
         cls.driver.quit()
 
     def setUp(self):
-        self.sh.load_url(SELENIUM_TEST_HTML, bypass_status_code_check=True)
+        self.sh.load_url("file://{}".format(SELENIUM_TEST_HTML), bypass_status_code_check=True)
 
     @patch("selenium.webdriver.Remote", autospec=True)
     def test_sauce_browser_valid(self, mock_sauce):
@@ -57,13 +57,13 @@ class SeleniumHelpersTestCase(unittest.TestCase):
         sh.create_driver(browserName="chrome", headless=True)
         self.assertTrue(mock_chrome.called)
 
-    @patch("selenium.webdriver.Firefox", autospec=True)
+    @patch("selenium.webdriver.Firefox")
     def test_firefox_browser_valid(self, mock_firefox):
         mock_driver = Mock(spec=mock_firefox)
         mock_firefox.return_value = mock_driver
         sh = selenium_helpers.SeleniumHelpers()
-        sh.create_driver(browserName="firefox")
-        mock_firefox.assert_called_once_with(firefox_binary=None)
+        sh.create_driver(browserName="firefox", headless=True)
+        self.assertTrue(mock_firefox.called)
 
     @patch("selenium.webdriver.PhantomJS", autospec=True)
     def test_phantomjs_browser_valid(self, mock_phantomjs):
@@ -120,50 +120,50 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_window_size_width_valid(self):
         width = self.sh.get_window_size(get_only_width=True)
-        self.assertEqual(width, 400)
+        self.assertEqual(width, 800)
 
     def test_get_window_size_width_value_valid(self):
         window_width = self.sh.get_window_size(get_only_width=True)
-        self.assertEqual(window_width, 400)
+        self.assertEqual(window_width, 800)
 
     def test_get_window_size_height_valid(self):
         height = self.sh.get_window_size(get_only_height=True)
-        self.assertEqual(height, 300)
+        self.assertEqual(height, 600)
 
     def test_get_window_size_height_value_valid(self):
         window_height = self.sh.get_window_size(get_only_height=True)
-        self.assertEqual(window_height, 300)
+        self.assertEqual(window_height, 600)
 
     def test_get_window_size_valid(self):
         width, height = self.sh.get_window_size()
-        self.assertEqual(width, 400)
-        self.assertEqual(height, 300)
+        self.assertEqual(width, 800)
+        self.assertEqual(height, 600)
 
     def test_get_window_size_value_valid(self):
         window_width, window_height = self.sh.get_window_size()
-        self.assertEqual(window_width, 400)
-        self.assertEqual(window_height, 300)
+        self.assertEqual(window_width, 800)
+        self.assertEqual(window_height, 600)
 
     def test_window_size_invalid(self):
         sh = selenium_helpers.SeleniumHelpers()
         self.assertRaises(selenium_helpers.DriverAttributeError, sh.get_window_size)
 
-    def test_add_coookie_is_valid(self):
+    @patch("selenium.webdriver.remote.webdriver.WebDriver.add_cookie")
+    def test_add_coookie_is_valid(self, mock_add_cookie):
         self.sh.add_cookie("qa", "test")
-        self.assertTrue(self.driver.get_cookie("qa"), True)
-
-    def test_add_cookie_is_false(self):
-        self.sh.add_cookie("qa", "test")
-        self.assertTrue(self.driver.get_cookie("no_cookie") is None)
+        self.assertTrue(mock_add_cookie.called)
 
     def test_add_cookie_expection(self):
         with self.assertRaises(selenium_helpers.DriverAttributeError):
             self.sh.add_cookie(["qa", "test"], "test")
 
-    def test_delete_cookie_is_valid(self):
+    @patch("selenium.webdriver.remote.webdriver.WebDriver.delete_cookie")
+    @patch("selenium.webdriver.remote.webdriver.WebDriver.add_cookie")
+    def test_delete_cookie_is_valid(self, mock_add_cookie, mock_delete_cookie):
         self.sh.add_cookie("qa", "test")
         self.sh.delete_cookie("qa")
-        self.assertEquals(self.driver.get_cookies(), [])
+        self.assertTrue(mock_add_cookie.called)
+        self.assertTrue(mock_delete_cookie.called)
 
     def test_delete_cookie_expection(self):
         with self.assertRaises(selenium_helpers.DriverAttributeError):
@@ -171,22 +171,22 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     @patch("selenium.webdriver.remote.webdriver.WebDriver.get")
     def test_load_url_bypass_valid(self, mock_get):
-        self.sh.load_url("www.google.com", bypass_status_code_check=True)
+        self.sh.load_url("www.meltmedia.com", bypass_status_code_check=True)
         self.assertTrue(mock_get.called)
 
     @patch("selenium.webdriver.remote.webdriver.WebDriver.get")
-    def test_load_url_valid(self, mock_get):
-        self.sh.load_url("http://www.google.com")
-        self.assertTrue(mock_get.called)
+    def test_load_url_valid(self, mock_request):
+        self.sh.load_url("http://www.meltmedia.com")
+        self.assertTrue(mock_request.called)
 
     def test_load_404_url_invalid(self):
-        self.assertRaises(selenium_helpers.DriverURLError, self.sh.load_url, url="http://www.google.com/404")
+        self.assertRaises(selenium_helpers.DriverURLError, self.sh.load_url, url="http://www.meltmedia.com/404")
 
     def test_load_url_invalid(self):
-        self.assertRaises(selenium_helpers.DriverURLError, self.sh.load_url, url="google.com")
+        self.assertRaises(selenium_helpers.DriverURLError, self.sh.load_url, url="meltmedia.com")
 
     def test_get_current_url_valid(self):
-        test_url = "http://www.google.com/"
+        test_url = "https://www.meltmedia.com/"
         self.sh.load_url(test_url)
         current_url = self.sh.get_current_url()
         self.assertEqual(current_url, test_url)
@@ -197,7 +197,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     @patch("selenium.webdriver.remote.webdriver.WebDriver.refresh")
     def test_refresh_driver_valid(self, mock_refresh):
-        self.sh.load_url("http://www.google.com")
+        self.sh.load_url("http://www.meltmedia.com")
         self.sh.refresh_driver()
         self.assertTrue(mock_refresh.called)
 
@@ -207,16 +207,16 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_viewport_size_width_value_valid(self):
         viewport_width = self.sh.get_viewport_size(get_only_width=True)
-        self.assertEqual(viewport_width, 400)
+        self.assertEqual(viewport_width, 800)
 
     def test_get_viewport_size_height_value_valid(self):
         viewport_height = self.sh.get_viewport_size(get_only_height=True)
-        self.assertEqual(viewport_height, 300)
+        self.assertEqual(viewport_height, 600)
 
     def test_get_viewport_size_values_valid(self):
         viewport_width, viewport_height = self.sh.get_viewport_size()
-        self.assertEqual(viewport_width, 400)
-        self.assertEqual(viewport_height, 300)
+        self.assertEqual(viewport_width, 800)
+        self.assertEqual(viewport_height, 600)
 
     def test_viewport_size_invalid(self):
         sh = selenium_helpers.SeleniumHelpers()
@@ -272,7 +272,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     @patch("selenium.webdriver.remote.webdriver.WebDriver.close")
     def test_close_window_valid(self, mock_close):
         sh = selenium_helpers.SeleniumHelpers()
-        sh.create_driver(browserName="phantomjs")
+        sh.create_driver(browserName="firefox", headless=True)
         sh.close_window()
         self.assertTrue(mock_close.called)
 
@@ -283,7 +283,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     @patch("selenium.webdriver.remote.webdriver.WebDriver.quit")
     def test_quit_window_valid(self, mock_quit):
         sh = selenium_helpers.SeleniumHelpers()
-        sh.create_driver(browserName="phantomjs")
+        sh.create_driver(browserName="firefox", headless=True)
         sh.quit_driver()
         self.assertTrue(mock_quit.called)
 
@@ -324,7 +324,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_valid(self):
         valid_css_selector = ".valid"
-        self.assertEqual(self.sh.get_element(valid_css_selector).location, {'y': 21.4375, 'x': 48})
+        self.assertEqual(self.sh.get_element(valid_css_selector).location, {'y': 21.0, 'x': 48.0})
 
     def test_get_invalid(self):
         self.assertRaises(selenium_helpers.ElementError, self.sh.get_element, ".invalid")
@@ -435,6 +435,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     def test_move_cursor_to_location_click_valid(self, mock_click):
         self.sh.move_cursor_to_location(15, 15, click=True)
         self.assertTrue(mock_click.called)
+
 
     def test_move_cursor_to_location_invalid(self):
         self.assertRaises(selenium_helpers.CursorLocationError, self.sh.move_cursor_to_location, x_position="")
@@ -848,11 +849,11 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_content_height_valid(self):
         height = self.sh.get_content_height()
-        self.assertEquals(height, 849)
+        self.assertEquals(height, 789)
 
     @patch("the_ark.selenium_helpers.SeleniumHelpers.execute_script")
     def test_get_content_height_invalid(self, mock_execute):
-        mock_execute.side_effect = Exception("Boo!")
+        mock_execute.side_effect = Exception("This is a test.")
         self.assertRaises(Exception, self.sh.get_content_height)
 
     def test_get_element_size_valid(self):
@@ -885,12 +886,12 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_element_location_valid(self):
         height = self.sh.get_element_location(".scrollable")
-        self.assertEquals(height, 296.4375)
+        self.assertEquals(height, 252.0)
 
     def test_get_element_location_with_both_returned(self):
         x, y = self.sh.get_element_location(".scrollable", get_both_positions=True)
         self.assertEquals(x, 8.0)
-        self.assertEquals(y, 296.4375)
+        self.assertEquals(y, 252.0)
 
     def test_get_element_location_with_x_only(self):
         width = self.sh.get_element_location(".scrollable", get_only_x_position=True)
@@ -899,7 +900,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     def test_get_element_location_with_element(self):
         element = self.sh.get_element(css_selector=".scrollable")
         height = self.sh.get_element_location(web_element=element)
-        self.assertEquals(height, 296.4375)
+        self.assertEquals(height, 252.0)
 
     def test_get_element_location_selenium_error(self):
         self.assertRaises(selenium_helpers.SeleniumHelperExceptions, self.sh.get_element_location,

--- a/tests/test_selenium_helpers.py
+++ b/tests/test_selenium_helpers.py
@@ -13,7 +13,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.sh = selenium_helpers.SeleniumHelpers()
-        cls.driver = cls.sh.create_driver(browserName="chrome", headless=True)
+        cls.driver = cls.sh.create_driver(browserName="phantomjs")
 
     @classmethod
     def tearDownClass(cls):
@@ -120,29 +120,29 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_window_size_width_valid(self):
         width = self.sh.get_window_size(get_only_width=True)
-        self.assertEqual(width, 800)
+        self.assertEqual(width, 400)
 
     def test_get_window_size_width_value_valid(self):
         window_width = self.sh.get_window_size(get_only_width=True)
-        self.assertEqual(window_width, 800)
+        self.assertEqual(window_width, 400)
 
     def test_get_window_size_height_valid(self):
         height = self.sh.get_window_size(get_only_height=True)
-        self.assertEqual(height, 600)
+        self.assertEqual(height, 300)
 
     def test_get_window_size_height_value_valid(self):
         window_height = self.sh.get_window_size(get_only_height=True)
-        self.assertEqual(window_height, 600)
+        self.assertEqual(window_height, 300)
 
     def test_get_window_size_valid(self):
         width, height = self.sh.get_window_size()
-        self.assertEqual(width, 800)
-        self.assertEqual(height, 600)
+        self.assertEqual(width, 400)
+        self.assertEqual(height, 300)
 
     def test_get_window_size_value_valid(self):
         window_width, window_height = self.sh.get_window_size()
-        self.assertEqual(window_width, 800)
-        self.assertEqual(window_height, 600)
+        self.assertEqual(window_width, 400)
+        self.assertEqual(window_height, 300)
 
     def test_window_size_invalid(self):
         sh = selenium_helpers.SeleniumHelpers()
@@ -207,16 +207,16 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_viewport_size_width_value_valid(self):
         viewport_width = self.sh.get_viewport_size(get_only_width=True)
-        self.assertEqual(viewport_width, 800)
+        self.assertEqual(viewport_width, 400)
 
     def test_get_viewport_size_height_value_valid(self):
         viewport_height = self.sh.get_viewport_size(get_only_height=True)
-        self.assertEqual(viewport_height, 600)
+        self.assertEqual(viewport_height, 300)
 
     def test_get_viewport_size_values_valid(self):
         viewport_width, viewport_height = self.sh.get_viewport_size()
-        self.assertEqual(viewport_width, 800)
-        self.assertEqual(viewport_height, 600)
+        self.assertEqual(viewport_width, 400)
+        self.assertEqual(viewport_height, 300)
 
     def test_viewport_size_invalid(self):
         sh = selenium_helpers.SeleniumHelpers()
@@ -849,7 +849,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_content_height_valid(self):
         height = self.sh.get_content_height()
-        self.assertEquals(height, 789)
+        self.assertEquals(height, 300)
 
     @patch("the_ark.selenium_helpers.SeleniumHelpers.execute_script")
     def test_get_content_height_invalid(self, mock_execute):
@@ -886,12 +886,12 @@ class SeleniumHelpersTestCase(unittest.TestCase):
 
     def test_get_element_location_valid(self):
         height = self.sh.get_element_location(".scrollable")
-        self.assertEquals(height, 252.0)
+        self.assertEquals(height, 269.0)
 
     def test_get_element_location_with_both_returned(self):
         x, y = self.sh.get_element_location(".scrollable", get_both_positions=True)
         self.assertEquals(x, 8.0)
-        self.assertEquals(y, 252.0)
+        self.assertEquals(y, 269.0)
 
     def test_get_element_location_with_x_only(self):
         width = self.sh.get_element_location(".scrollable", get_only_x_position=True)
@@ -900,7 +900,7 @@ class SeleniumHelpersTestCase(unittest.TestCase):
     def test_get_element_location_with_element(self):
         element = self.sh.get_element(css_selector=".scrollable")
         height = self.sh.get_element_location(web_element=element)
-        self.assertEquals(height, 252.0)
+        self.assertEquals(height, 269.0)
 
     def test_get_element_location_selenium_error(self):
         self.assertRaises(selenium_helpers.SeleniumHelperExceptions, self.sh.get_element_location,

--- a/the_ark/screen_capture.py
+++ b/the_ark/screen_capture.py
@@ -18,8 +18,9 @@ class Screenshot:
     A helper class for taking screenshots using a Selenium Helper instance
     """
     def __init__(self, selenium_helper, paginated=False, header_ids=None, footer_ids=None,
-                 scroll_padding=DEFAULT_SCROLL_PADDING, pixel_match_offset=DEFAULT_PIXEL_MATCH_OFFSET,
-                 file_extenson=SCREENSHOT_FILE_EXTENSION, resize_delay=0):
+                 content_container_selector="html", scroll_padding=DEFAULT_SCROLL_PADDING,
+                 pixel_match_offset=DEFAULT_PIXEL_MATCH_OFFSET, file_extenson=SCREENSHOT_FILE_EXTENSION,
+                 resize_delay=0):
         """
         Initializes the Screenshot class. These variable will be used throughout to help determine how to capture pages
         for this website.
@@ -44,6 +45,7 @@ class Screenshot:
         self.paginated = paginated
         self.headers = header_ids
         self.footers = footer_ids
+        self.content_container_selector = content_container_selector
         self.scroll_padding = scroll_padding
         self.pixel_match_offset = pixel_match_offset
         self.file_extenson = "png"
@@ -268,7 +270,7 @@ class Screenshot:
         current_scroll_position = self.sh.get_window_current_scroll_position()
 
         if not viewport_only:
-            content_height = self.sh.get_content_height()
+            content_height = self.sh.get_content_height(self.content_container_selector)
             if content_height > self.max_height:
                 self.sh.resize_browser(width, self.max_height + self.head_padding)
                 self.sh.scroll_window_to_position()

--- a/the_ark/screen_capture.py
+++ b/the_ark/screen_capture.py
@@ -18,9 +18,8 @@ class Screenshot:
     A helper class for taking screenshots using a Selenium Helper instance
     """
     def __init__(self, selenium_helper, paginated=False, header_ids=None, footer_ids=None,
-                 content_container_selector="html", scroll_padding=DEFAULT_SCROLL_PADDING,
-                 pixel_match_offset=DEFAULT_PIXEL_MATCH_OFFSET, file_extenson=SCREENSHOT_FILE_EXTENSION,
-                 resize_delay=0):
+                 scroll_padding=DEFAULT_SCROLL_PADDING, pixel_match_offset=DEFAULT_PIXEL_MATCH_OFFSET,
+                 file_extenson=SCREENSHOT_FILE_EXTENSION, resize_delay=0, content_container_selector="html"):
         """
         Initializes the Screenshot class. These variable will be used throughout to help determine how to capture pages
         for this website.

--- a/the_ark/selenium_helpers.py
+++ b/the_ark/selenium_helpers.py
@@ -137,9 +137,17 @@ class SeleniumHelpers:
                       "{0}".format(get_window_size_error)
             raise DriverAttributeError(msg=message, stacktrace=traceback.format_exc())
 
-    def get_content_height(self):
+    def get_content_height(self, css_selector="html"):
+        """
+        This will return the content height of a website based on an element height. The element is defaulted to 'html'
+        but a custom CSS Selector can be passed in if 'html' does not get the full height of the content.
+        :param
+            -   css_selector:   string - The specific element that will be interacted with.
+        :return
+            - integer - The height of the content area based on the css_selector used.
+        """
         try:
-            return int(round(self.get_element_size("html")))
+            return int(round(self.get_element_size(css_selector)))
         except Exception as script_error:
             message = "Unable to get the height of the page content.\n" \
                       "{0}".format(script_error)


### PR DESCRIPTION
## JIRA Ticket(s)

* https://jira.meltdev.com/browse/QAP-1260

## What does this PR do?

This adds the ability to pass in a custom "content_container_selector". If the default 'html' selector does not get a good full screen capture in headless the user can add "content_container_selector":"{new_selector}" to the any of the environments and full page screens should now happen.

## How should this update be tested?

<details>
  <summary>Pull down the CAN config update in Hippo Sites: feature_QAP-1189 and run that through Hippo.</summary>
</details>

<details>
  <summary>Information for request to run CAN</summary>

  * "project": "can",
  * "url": "https://can-webapp-qa-main.meltdemo.com",
  * "branch": "master",
</details>